### PR TITLE
add custom sorter function

### DIFF
--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -12,38 +12,6 @@ const BUFFER_CAPACITY: usize = 4_000_000_000;
 #[derive(Debug, PartialEq, PartialOrd)]
 struct CorrResults(String, f64, f64, i32);
 
-// impl  Sortable for  CorrResults {
-
-//  fn decode<R: Read>(reader: &mut R) -> Option<Self> {
-
-//        todo!()
-//    }
-
-//    fn encode<W: Write>(&self, writer: &mut W) {
-
-//        writer.write_fmt(format_args!("{} {} {}",self.0,self.1,self.2)).unwrap();
-
-//    }
-
-// }
-
-// fn ext_sorter (unsorted_vec:Vec<CorrResults>,file_name:&str,n_top:usize)-> std::io::Result<Vec<CorrResults>>{
-
-//    File::create(file_name)?;
-
-//    let sorter = ExternalSorter::new().with_segment_size(4_000_000);
-
-//    let into_iterator = unsorted_vec.into_iter();
-
-//    let sorted = sorter.sort_by(into_iterator, |a,b|b.1.abs().partial_cmp(&a.1.abs()).unwrap())?.collect::<Vec<CorrResults>>();
-
-//sorted.collect::<Vec<CorrResults>>().truncate(n_top);
-
-//    Ok(sorted)
-
-//corr_results.sort_by(|a,b|b.1.abs().partial_cmp(&a.1.abs()).unwrap());
-
-// }
 
 pub fn sort_write_to_file(
     filename: String,

--- a/src/sorter.rs
+++ b/src/sorter.rs
@@ -64,3 +64,60 @@ pub fn sort_write_to_file(
 pub fn create_large_file(filename: &str) {
     File::create(filename).unwrap();
 }
+
+pub fn float_sorter(unsorted:& mut [f64]){
+    // custom function to sort floats with nan and inf descending order
+    unsorted.sort_by(|&a, &b| {
+        match (a.is_nan()| a.is_infinite(), b.is_nan()|b.is_infinite()) {
+            (true, true) => Ordering::Equal,
+            (true, false) => Ordering::Greater,
+            (false, true) => Ordering::Less,
+            (false, false) => b.partial_cmp(&a).unwrap(),
+        }
+    });
+}
+
+
+mod tests{
+
+
+    //custom function to to be able to compare  vec with floats
+ 
+    fn eq_with_nan_eq(a: f64, b: f64) -> bool {
+        ((a.is_nan()| a.is_infinite()) &&
+         (b.is_nan()| b.is_infinite())) || (a == b)
+    }
+    
+    fn vec_compare(va: &[f64], vb: &[f64]) -> bool {
+        (va.len() == vb.len()) && 
+         va.iter()
+           .zip(vb)
+           .all(|(a,b)| eq_with_nan_eq(*a,*b))
+    }
+
+    #[test]
+
+    fn test_float_sorter(){
+        use super::float_sorter;
+
+
+        
+        let  mut test_cases:[(Vec<f64>, Vec<f64>);6] = [( vec![f64::NAN,12.1,11.1,1.1],vec![12.1,11.1,1.1,f64::NAN]),
+        (vec![2.1,1.1,2.3,f64::NAN],vec![2.3,2.1,1.1,f64::NAN]),
+        (vec![f64::NAN,f64::NAN,9.1],vec![9.1,f64::NAN,f64::NAN]),
+        (vec![f64::INFINITY,1.12,f64::INFINITY,42.1],vec![42.1,1.12,f64::INFINITY,f64::INFINITY]),
+        (vec![1.1,1.4,1.5,12.1],vec![12.1,1.5,1.4,1.1]),
+        (vec![ f64::INFINITY,f64::INFINITY,2.13,5.3,f64::NAN,12.1,f64::INFINITY,5.6,f64::NAN,f64::NAN,8.32],
+            vec![12.1, 8.32, 5.6, 5.3, 2.13, f64::INFINITY, f64::INFINITY, f64::NAN, f64::INFINITY, f64::NAN, f64::INFINITY]
+        )
+        ];
+
+        for (test_case,expected_case) in &mut test_cases{
+
+            float_sorter(test_case);
+            assert!(vec_compare(test_case, expected_case),"testcase failed for {:?}=={:?}",expected_case,test_case)
+        }
+
+    }
+    
+}


### PR DESCRIPTION
the current sorter for rust is not consistent
no  method exists in the standard library to sorting vec of floats in the given order
the only method that come close  but fails on the precedence
is see

(https://doc.rust-lang.org/std/primitive.f64.html#method.total_cmp)

the above pr create  a custom sorter in a descending order also handling case for sorting
nan and inf values in the same order

``` rust
for` example 
given a vec of floats
let mut results = vec![f64::NAN,1.21,1.41,-4.5]
//expected results after sorting 

vec![-4.5,1.41,1.21,f64::NAN]



```